### PR TITLE
PrivacyGuard: skip icon lookup for OP_NONE

### DIFF
--- a/src/com/android/settings/applications/AppOpsDetails.java
+++ b/src/com/android/settings/applications/AppOpsDetails.java
@@ -195,14 +195,14 @@ public class AppOpsDetails extends SettingsPreferenceFragment {
                     mPackageInfo.applicationInfo.uid, mPackageInfo.packageName, true);
             for (final AppOpsState.AppOpEntry entry : entries) {
                 String perm = null;
-                int op = 0;
+                int op = -1;
                 // Find the first permission with a known name
                 for (int i = 0; i < entry.getNumOpEntry() && perm == null; i++) {
                     op = entry.getOpEntry(i).getOp();
                     perm = AppOpsManager.opToPermission(op);
                 }
                 Drawable icon = getIconByPermission(perm);
-                if (icon == null && op != 0 && OP_ICONS.containsKey(op)) {
+                if (icon == null && op != -1 && OP_ICONS.containsKey(op)) {
                     icon = getActivity().getDrawable(OP_ICONS.get(op));
                 }
                 if (icon == null) {


### PR DESCRIPTION
* OP 0 (zero) is OP_COARSE_LOCATION. We only want to
  skip a lookup when the OP is OP_NONE (-1).

Change-Id: I64366aff1aa90bb71c2b99dae5485b0262860107